### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/AVW-Workshop/58f21bb1-5139-4fcc-be46-8ed92c6efe66/57f0504c-8d84-4fb1-9dd6-ef5c13cfcb8f/_apis/work/boardbadge/35d4c310-e7da-4022-8312-722348628330)](https://dev.azure.com/AVW-Workshop/58f21bb1-5139-4fcc-be46-8ed92c6efe66/_boards/board/t/57f0504c-8d84-4fb1-9dd6-ef5c13cfcb8f/Microsoft.RequirementCategory)
 # CodeToCloud with GitHub and Azure DevOps Workshop - Source
 This repository contains the source code for the CodeToCloud workshop. Please follow the instructions in the [CodeToCloud-Student](https://github.com/XpiritBV/CodeToCloud-Student) repository to use this.
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#5](https://dev.azure.com/AVW-Workshop/58f21bb1-5139-4fcc-be46-8ed92c6efe66/_workitems/edit/5). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.